### PR TITLE
Use p2p build script when user plugin does not implement both boxes

### DIFF
--- a/script/build.tcl
+++ b/script/build.tcl
@@ -329,8 +329,13 @@ foreach freq [list 250mhz 322mhz] {
     read_verilog -quiet ${box_plugin}/${box}_address_map.v
     lappend include_dirs $box_plugin
 
-    cd $user_plugin
-    source build_${box}.tcl
+    if {![file exists ${user_plugin}/build_${box}.tcl]} {
+        cd ${plugin_dir}/p2p
+        source build_${box}.tcl
+    } else {
+        cd $user_plugin
+        source build_${box}.tcl
+    }
     cd $script_dir
 }
 set_property include_dirs $include_dirs [current_fileset]


### PR DESCRIPTION
When the user plugin does not implement both the boxes, `build.tcl` still sources box build script from the user specified path. Ideally it should load the build script for the default p2p box if the user plugin does not implement a box.

Note, `build.tcl` does source the correct `${box_plugin}/${box}_address_map.v` and `${box_plugin}/${box}_axi_crossbar.tcl`, but does not source the correct `build_${box}.tcl`

Changes in this PR work with the command `vivado -mode tcl -source ./build.tcl -tclargs -board_repo /datadrive/board-files -board au50 -impl 1 -post_impl 1 -user_plugin ../plugin/byte-counter` and following repo structure:

```
├── plugin
│   ├── byte-counter
│   │   ├── box_250mhz
│   │   │   ├── box_250mhz_address_map_inst.vh
│   │   │   ├── box_250mhz_address_map.v
│   │   │   ├── box_250mhz_axi_crossbar.tcl
│   │   │   └── user_plugin_250mhz_inst.vh
│   │   ├── build_box_250mhz.tcl
│   │   └── byte_counter_250mhz.sv
│   └── p2p
│       ├── box_250mhz
│       │   ├── box_250mhz_address_map_inst.vh
│       │   ├── box_250mhz_address_map.v
│       │   ├── box_250mhz_axi_crossbar.tcl
│       │   └── user_plugin_250mhz_inst.vh
│       ├── box_322mhz
│       │   ├── box_322mhz_address_map_inst.vh
│       │   ├── box_322mhz_address_map.v
│       │   ├── box_322mhz_axi_crossbar.tcl
│       │   └── user_plugin_322mhz_inst.vh
│       ├── build_box_250mhz.tcl
│       ├── build_box_322mhz.tcl
│       ├── p2p_250mhz.sv
│       └── p2p_322mhz.sv
```