### PR TITLE
Update qdma_subsystem_c2h.sv

### DIFF
--- a/src/qdma_subsystem/qdma_subsystem_c2h.sv
+++ b/src/qdma_subsystem/qdma_subsystem_c2h.sv
@@ -176,7 +176,7 @@ module qdma_subsystem_c2h #(
       m_axis_qdma_c2h_mty <= 0;
     end
     else if (axis_c2h_tvalid && axis_c2h_tready) begin
-      m_axis_qdma_c2h_mty <= (axis_c2h_tlast) ? (64 - axis_c2h_tuser_size[5:0]) : 0;
+       m_axis_qdma_c2h_mty <= (axis_c2h_tlast) ? (axis_c2h_tuser_size[5:0] == 0) ? 0 : (64 - axis_c2h_tuser_size[5:0]) : 0;
     end
   end
 


### PR DESCRIPTION
Fix for tuser_size to mty translation in c2h.

For aligned packets (64 bytes), on the last cc the user_size will be 64 (7'b100000) and the mty should be zero since all the bytes are valid. However, since only 6 bits are used from the user_size, that value is zero, which means the calculated mty is 64, signaling to the QDMA that all the bytes in the last cc are invalid.