### PR TITLE
Esnet patches pr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ vivado*.str
 
 # Ignore .Xil directory
 .Xil
+
+# Ignore emacs backup files
+*~
+
+# Ignore build directory
+build

--- a/constr/au280/timing.xdc
+++ b/constr/au280/timing.xdc
@@ -39,5 +39,5 @@ resize_pblock [get_pblocks pblock_qdma_subsystem] -add {SLR0}
 
 create_pblock pblock_cmac_subsystem
 add_cells_to_pblock [get_pblocks pblock_cmac_subsystem] [get_cells -quiet {cmac_port*.cmac_subsystem_inst}]
-add_cells_to_pblock [get_pblocks pblock_cmac_subsystem] [get_cells -quiet {box_322mhz_inst}]
+#add_cells_to_pblock [get_pblocks pblock_cmac_subsystem] [get_cells -quiet {box_322mhz_inst}]
 resize_pblock [get_pblocks pblock_cmac_subsystem] -add {SLR2}

--- a/script/build.tcl
+++ b/script/build.tcl
@@ -50,7 +50,6 @@ proc _do_post_impl {build_dir top impl_run {zynq_family 0}} {
     }
 }
 
-
 # Directory variables
 set root_dir [file normalize ..]
 set constr_dir ${root_dir}/constr
@@ -63,6 +62,7 @@ set src_dir ${root_dir}/src
 #   board        Board name
 #   tag          Tag to identify the build
 #   overwrite    Overwrite existing build results
+#   rebuild      Update build directory but respect overwrite
 #   jobs         Number of jobs for synthesis and implementation
 #   synth_ip     Synthesize IPs before creating design project
 #   impl         Run implementation after creating design project
@@ -82,6 +82,7 @@ array set build_options {
     -board       au250
     -tag         ""
     -overwrite   0
+    -rebuild     0
     -jobs        8
     -synth_ip    1
     -impl        0
@@ -157,19 +158,24 @@ if {![string equal $tag ""]} {
 
 set build_dir [file normalize ${root_dir}/build/${build_name}]
 if {[file exists $build_dir]} {
-    puts "Found existing build directory $build_dir"
-    puts "  1. Update existing build directory (default)"
-    puts "  2. Delete existing build directory and create a new one"
-    puts "  3. Exit"
-    puts -nonewline {Choose an option: }
-    gets stdin ans
-    if {[string equal $ans "2"]} {
-        file delete -force $build_dir
-        puts "Deleted existing build directory $build_dir"
-        file mkdir $build_dir
-    } elseif {[string equal $ans "3"]} {
-        puts "Build directory existed. Try to specify a different design tag"
-        exit
+    if {!$rebuild } {
+        puts "Found existing build directory $build_dir"
+        puts "  1. Update existing build directory (default)"
+        puts "  2. Delete existing build directory and create a new one"
+        puts "  3. Exit"
+        puts -nonewline {Choose an option: }
+        gets stdin ans
+        if {[string equal $ans "2"]} {
+            file delete -force $build_dir
+            puts "Deleted existing build directory $build_dir"
+            file mkdir $build_dir
+        } elseif {[string equal $ans "3"]} {
+            puts "Build directory existed. Try to specify a different design tag"
+            exit
+        }
+    } else {
+	file delete -force $build_dir/open_nic_shell
+	puts "Deleted existing build director $build_dir/open_nic_shell"
     }
 } else {
     file mkdir $build_dir


### PR DESCRIPTION
Mostly enhancements to build.tcl to improve incremental build options, as well as support for user version tracking in the bit files.  Removed constraint that CMAC and box_322 need to be in the same pblock.