### PR TITLE
fix: au55n qdma configuration issue

### DIFF
--- a/src/qdma_subsystem/vivado_ip/qdma_no_sriov_au55n.tcl
+++ b/src/qdma_subsystem/vivado_ip/qdma_no_sriov_au55n.tcl
@@ -1,4 +1,4 @@
- # *************************************************************************
+# *************************************************************************
 #
 # Copyright 2020 Xilinx, Inc.
 #
@@ -17,38 +17,34 @@
 # *************************************************************************
 set qdma qdma_no_sriov
 create_ip -name qdma -vendor xilinx.com -library ip -module_name $qdma -dir ${ip_build_dir}
-set_property -dict {   
-    CONFIG.mode_selection {Advanced} 
-    CONFIG.pl_link_cap_max_link_width {X16} 
-    CONFIG.pl_link_cap_max_link_speed {8.0_GT/s} 
-    CONFIG.en_transceiver_status_ports {false} 
-    CONFIG.dsc_byp_mode {Descriptor_bypass_and_internal} 
-    CONFIG.testname {st} CONFIG.dma_reset_source_sel {Phy_Ready} 
-    CONFIG.pf0_bar2_scale_qdma {Megabytes} 
-    CONFIG.pf0_bar2_size_qdma {4} 
-    CONFIG.pf1_bar2_scale_qdma {Megabytes} 
-    CONFIG.pf1_bar2_size_qdma {4} 
-    CONFIG.pf2_bar2_scale_qdma {Megabytes} 
-    CONFIG.pf2_bar2_size_qdma {4} 
-    CONFIG.pf3_bar2_scale_qdma {Megabytes} 
-    CONFIG.pf3_bar2_size_qdma {4} 
-    CONFIG.pf0_device_id {903F} 
-    CONFIG.pf2_device_id {923F} 
-    CONFIG.pf3_device_id {933F} 
-    CONFIG.PF0_SRIOV_VF_DEVICE_ID {A03F} 
-    CONFIG.PF1_SRIOV_VF_DEVICE_ID {A13F} 
-    CONFIG.PF2_SRIOV_VF_DEVICE_ID {A23F} 
-    CONFIG.PF3_SRIOV_VF_DEVICE_ID {A33F} 
-    CONFIG.PF0_MSIX_CAP_TABLE_SIZE_qdma {009} 
-    CONFIG.dma_intf_sel_qdma {AXI_Stream_with_Completion} 
+set_property -dict {
+    CONFIG.mode_selection {Advanced}
+    CONFIG.pl_link_cap_max_link_width {X16}
+    CONFIG.pl_link_cap_max_link_speed {8.0_GT/s}
+    CONFIG.en_transceiver_status_ports {false}
+    CONFIG.dsc_byp_mode {Descriptor_bypass_and_internal}
+    CONFIG.testname {st}
+    CONFIG.pf1_pciebar2axibar_2 {0x0000000000000000}
+    CONFIG.pf2_pciebar2axibar_2 {0x0000000000000000}
+    CONFIG.pf3_pciebar2axibar_2 {0x0000000000000000}
+    CONFIG.dma_reset_source_sel {Phy_Ready}
+    CONFIG.pf0_bar2_scale_qdma {Megabytes}
+    CONFIG.pf0_bar2_size_qdma {4}
+    CONFIG.pf1_bar2_scale_qdma {Megabytes}
+    CONFIG.pf1_bar2_size_qdma {4}
+    CONFIG.pf2_bar2_scale_qdma {Megabytes}
+    CONFIG.pf2_bar2_size_qdma {4}
+    CONFIG.pf3_bar2_scale_qdma {Megabytes}
+    CONFIG.pf3_bar2_size_qdma {4}
+    CONFIG.PF0_MSIX_CAP_TABLE_SIZE_qdma {009}
+    CONFIG.PF1_MSIX_CAP_TABLE_SIZE_qdma {008}
+    CONFIG.PF2_MSIX_CAP_TABLE_SIZE_qdma {008}
+    CONFIG.PF3_MSIX_CAP_TABLE_SIZE_qdma {008}
+    CONFIG.dma_intf_sel_qdma {AXI_Stream_with_Completion}
+    CONFIG.en_axi_mm_qdma {false}
     CONFIG.SYS_RST_N_BOARD_INTERFACE {pcie_perstn}
     CONFIG.PCIE_BOARD_INTERFACE {pci_express_x16}
-    CONFIG.en_axi_mm_qdma {false}
     CONFIG.xlnx_ref_board {AU55N}
-    CONFIG.en_gt_selection {true} 
-    CONFIG.select_quad {GTY_Quad_227}
-    CONFIG.pcie_blk_locn {PCIE4C_X1Y1} 
-
 } [get_ips $qdma]
 set_property CONFIG.tl_pf_enable_reg $num_phys_func [get_ips $qdma]
 set_property CONFIG.num_queues $num_queue [get_ips $qdma]


### PR DESCRIPTION
OpenNIC on U55N can't send packet out of ports. In RX direction, all packets received from both ports received by port on on host CPU side.

Original qdma_no_sriov_au55n.tcl is very different than other board's. After use the same configuration of QDMA as other boards, both RX and TX works on U55N.

Signed-off-by: Zhiyi Sun <zhiyis@amd.com>